### PR TITLE
Remove unused import

### DIFF
--- a/src/languages/mkb.js
+++ b/src/languages/mkb.js
@@ -7,8 +7,6 @@ Category: scripting
 */
 // node tools/build.js -n mkb
 
-import { KEYWORDS } from "./lib/ecmascript";
-
 export default function(hljs) {
 
     const MKB_ACTIONS = [


### PR DESCRIPTION
Having this import will prevent one from using the prototype in an environment where bundling is already included